### PR TITLE
Fix proxy for http search for an invalid json obeject

### DIFF
--- a/src/android/ChromeProxy.java
+++ b/src/android/ChromeProxy.java
@@ -131,7 +131,7 @@ public class ChromeProxy extends CordovaPlugin {
                         }
                     } else {
                         if (rules.has("proxyForHttp")) {
-                            JSONObject rule = rules.getJSONObject("httpProxy");
+                            JSONObject rule = rules.getJSONObject("proxyForHttp");
                             setHttpProxy(rule, "http", nonProxyHosts);
                         }
                         if (rules.has("proxyForHttps")) {


### PR DESCRIPTION
Hi just a little fix for setting an http proxy on android.


ps: I'm not verify if  IOS  part have the same problem. 